### PR TITLE
Make `DetectCiEnvironment.detectCiEnvironment` public

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Java] Make `DetectCiEnvironment.detectCiEnvironment` public
 
 ## [9.0.3] - 2022-03-04
 ### Fixed

--- a/java/src/main/java/io/cucumber/cienvironment/DetectCiEnvironment.java
+++ b/java/src/main/java/io/cucumber/cienvironment/DetectCiEnvironment.java
@@ -7,7 +7,14 @@ public final class DetectCiEnvironment {
     private DetectCiEnvironment() {
     }
 
-    static Optional<CiEnvironment> detectCiEnvironment(Map<String, String> env) {
+    /**
+     * Detects the ci system currently in use based on well known environment
+     * variables.
+     *
+     * @param env the environment variables (e.g {@code System.getenv()}
+     * @return the detected ci system
+     */
+    public static Optional<CiEnvironment> detectCiEnvironment(Map<String, String> env) {
         return CiEnvironments.TEMPLATES.stream()
                 .map(ciEnvironment -> ciEnvironment.detect(env))
                 .filter(Optional::isPresent)

--- a/java/src/test/java/io/cucumber/CiEnvironmentExample.java
+++ b/java/src/test/java/io/cucumber/CiEnvironmentExample.java
@@ -1,4 +1,8 @@
-package io.cucumber.cienvironment;
+package io.cucumber;
+
+import io.cucumber.cienvironment.CiEnvironment;
+
+import java.util.Optional;
 
 import static io.cucumber.cienvironment.DetectCiEnvironment.detectCiEnvironment;
 


### PR DESCRIPTION
The method `DetectCiEnvironment.detectCiEnvironment` was accidentally made
package private in 2ae8bd862e5d2445bdec1fe36409c76416c58820 preventing https://github.com/cucumber/cucumber-jvm/pull/2494.


### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Go over all the following points, and put an `x` in all the boxes that apply.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [x] My change requires a change to the documentation.
  - [x] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.
