### PR TITLE
CI: Keep only in-support Ruby versions in the matrix

### DIFF
--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: '3.0'
+          ruby-version: 3.2
           bundler-cache: true
           working-directory: ruby
       - name: Synchronize CiEnvironments.json

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -21,9 +21,9 @@ jobs:
         ruby: [3.1, 3.2]
         include:
           - os: windows-latest
-            ruby: '3.2'
+            ruby: 3.2
           - os: macos-latest
-            ruby: '3.2'
+            ruby: 3.2
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        ruby: ['2.5', '2.6', '2.7', '3.0', 3.1, 3.2]
+        ruby: [3.1, 3.2]
         include:
           - os: windows-latest
             ruby: '3.2'

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -18,12 +18,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        ruby: ['2.5', '2.6', '2.7', '3.0']
+        ruby: ['2.5', '2.6', '2.7', '3.0', 3.1, 3.2]
         include:
           - os: windows-latest
-            ruby: '3.0'
+            ruby: '3.2'
           - os: macos-latest
-            ruby: '3.0'
+            ruby: '3.2'
 
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
### 🤔 What's changed?

- Add Ruby 3.2
- Add Ruby 3.1
- Drop all other versions!
- Use Ruby 3.2 as the "operating Ruby" when doing things.

An upcoming change could drop support for ancient Ruby versions in the CI matrix.

<!-- Describe your changes in detail -->

### ⚡️ What's your motivation? 

All Ruby version < 3 are out of support.

3.0 will EOL soon.

https://www.ruby-lang.org/en/downloads/

To conserve CI resources, we keep the two latest available versions of the language in the CI matrix.

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

n/a

### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.

