### PR TITLE
Rubygem metadata: drop "Mailing List" link

### DIFF
--- a/ruby/cucumber-ci-environment.gemspec
+++ b/ruby/cucumber-ci-environment.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |s|
     'bug_tracker_uri' => 'https://github.com/cucumber/ci-environment/issues',
     'changelog_uri' => 'https://github.com/cucumber/ci-environment/blob/main/CHANGELOG.md',
     'documentation_uri' => 'https://cucumber.io/docs/gherkin/',
-    'mailing_list_uri' => 'https://groups.google.com/forum/#!forum/cukes',
     'source_code_uri' => 'https://github.com/cucumber/ci-environment/tree/main/ruby'
   }
 


### PR DESCRIPTION

### 🤔 What's changed?

This change removes a link which is visible on the Rubygems.org page (update upon release of the gem, which is in the future).


### ⚡️ What's your motivation? 

We do not currently run a Mailing List, so this makes sense. Our fora and channels to find support are findable via the other links.


I learned that we have an active StackOverflow presence, and our Slack channel.

Well, those are the places. They do not match "Mailing List".

### 🏷️ What kind of change is this?

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

n/a

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----
