### PR TITLE
CI: Use full versions of actions/checkout

### DIFF
--- a/.github/workflows/prerelease-checks.yml
+++ b/.github/workflows/prerelease-checks.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
 
       - name: Check commit has been pushed on origin/main
         run: |

--- a/.github/workflows/release-github.yml
+++ b/.github/workflows/release-github.yml
@@ -20,7 +20,7 @@ jobs:
       contents: write
 
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - uses: cucumber/action-create-github-release@v1.1.1
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-java.yml
+++ b/.github/workflows/release-java.yml
@@ -21,7 +21,7 @@ jobs:
     environment: Release
 
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-java@v3
         with:

--- a/.github/workflows/release-javascript.yml
+++ b/.github/workflows/release-javascript.yml
@@ -21,7 +21,7 @@ jobs:
     environment: Release
 
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release-ruby.yml
+++ b/.github/workflows/release-ruby.yml
@@ -21,7 +21,7 @@ jobs:
     environment: Release
 
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/test-go.yml
+++ b/.github/workflows/test-go.yml
@@ -22,7 +22,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+        uses: actions/checkout@v4
       - name: lint
         working-directory: go
         run: gofmt -w .

--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -27,7 +27,7 @@ jobs:
             java: '16'
 
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -21,7 +21,7 @@ jobs:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test-ruby.yml
+++ b/.github/workflows/test-ruby.yml
@@ -27,7 +27,7 @@ jobs:
             ruby: 3.2
 
     steps:
-      - uses: actions/checkout@3df4ab11eba7bda6032a0b82a6bb43b11571feac # v4
+      - uses: actions/checkout@v4
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:


### PR DESCRIPTION


### 🤔 What's changed?

In CI, use a major, rather than a specific commit ref, for the GitHub Actions.

### ⚡️ What's your motivation? 

Would like to see fewer PRs from bots that update things that don't really matter.

### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

n/a

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
