### PR TITLE
Fix Python build

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
   "importlib_resources",
   "python-dotenv"
 ]
+dynamic = [
+  "optional-dependencies"
+]
 description = "This library detects the CI environment based on environment variables defined by CI servers."
 readme = {file = "README.md", content-type = "text/markdown"}
 license = {text = "MIT"}


### PR DESCRIPTION
### 🤔 What's changed?

Allow test dependencies to be set by `setup.cfg`.

See the documentation at: https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#static-vs-dynamic-metadata

### ⚡️ What's your motivation? 

Build broke with:

```
 × Getting requirements to build wheel did not run successfully.
  │ exit code: 1
  ╰─> [51 lines of output]
      /tmp/pip-build-env-25mh8v9e/overlay/lib/python3.8/site-packages/setuptools/config/_apply_pyprojecttoml.py:75: _MissingDynamic: `optional-dependencies` defined outside of `pyproject.toml` is ignored.
      !!
      
              ********************************************************************************
              The following seems to be defined outside of `pyproject.toml`:
      
              `optional-dependencies = {'test': ['tox']}`
      
              According to the spec (see the link below), however, setuptools CANNOT
              consider this value unless `optional-dependencies` is listed as `dynamic`.
      
              https://packaging.python.org/en/latest/specifications/declaring-project-metadata/
      
              To prevent this problem, you can list `optional-dependencies` under `dynamic` or alternatively
              remove the `[project]` table from your file and rely entirely on other means of
              configuration.
              ********************************************************************************
      
      !!
```      

### ♻️ Anything particular you want feedback on?

@elchupanebrej you originally added the build in #209. Does this make sense? Are there more elegant ways to resolve this? Feel free to comment or send a PR, even if this was already merged.


### 📋 Checklist:

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
