### PR TITLE
CI: use jdk17 in test-java.yml

### DIFF
--- a/.github/workflows/test-java.yml
+++ b/.github/workflows/test-java.yml
@@ -19,12 +19,12 @@ jobs:
       matrix:
         os:
           - ubuntu-latest
-        java: ['11', '16']
+        java: ['11', '17']
         include:
           - os: windows-latest
-            java: '16'
+            java: '17'
           - os: macos-latest
-            java: '16'
+            java: '17'
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
### 🤔 What's changed?

This changes Java's CI matrix by updating the higher-numbered JDK version from 16 to 17.

"JDK 17 reached General Availability on 14 September 2021". https://openjdk.org/projects/jdk/17/

### ⚡️ What's your motivation? 

There were failures in CI for macOS, in some automated PR's CI run: 

https://github.com/cucumber/ci-environment/actions/runs/9382697329/job/25834679741?pr=258

For macOS-latest + jdk version 16 we got:

>  Trying to resolve the latest version from remote
>  **Error**: Could not find satisfied version for SemVer '16'. 
>  **Available versions**: 22.0.1+8, 22.0.0+36, 21.0.3+9.0.LTS, 21.0.2+13.0.LTS, 21.0.1+12.0.LTS, 21.0.0+35.0.LTS, 20.0.2+9, 20.0.1+9, 20.0.0+36, 19.0.2+7, 19.0.1+10, 19.0.0+36, 18.0.2+101, 18.0.2+9, 18.0.1+10, 18.0.0+36, 17.0.11+9, 17.0.10+7, 17.0.9+9, 17.0.8+101, 17.0.8+7, 17.0.7+7, 17.0.6+10, 17.0.5+8, 17.0.4+101, 17.0.4+8, 17.0.3+7, 17.0.2+8, 17.0.1+12, 17.0.0+35, 11.0.23+9, 11.0.22+7.1, 11.0.22+7, 11.0.21+9, 11.0.20+101, 11.0.20+8, 11.0.19+7, 11.0.18+10, 11.0.17+8, 11.0.16+101, 11.0.16+8, 11.0.15+10

### 🏷️ What kind of change is this?


- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

Is there a centralized place where decisions on CI build matrix evolution happen?

### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)

