### PR TITLE
Python: Replace publish action

### DIFF
--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Show Python version
         run: python --version
 
-      - name: Check build
+      - name: Build package
         run: |
           python -m pip install build twine
           python -m build

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -1,8 +1,8 @@
-name: Release pip package
+name: Release Python
 
 on:
   push:
-    branches: [release/*]
+    branches: [ release/* ]
 
 jobs:
   release:
@@ -26,6 +26,12 @@ jobs:
       - name: Show Python version
         run: python --version
 
-      - uses: cucumber/action-publish-pypi@v3.0.0
+      - name: Install Python package dependencies
+        run: |
+          python -m pip install build twine
+          python -m build
+          twine check --strict dist/*
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
         with:
-          working-directory: "python"
+          packages-dir: python/dist

--- a/.github/workflows/release-python.yaml
+++ b/.github/workflows/release-python.yaml
@@ -26,11 +26,12 @@ jobs:
       - name: Show Python version
         run: python --version
 
-      - name: Install Python package dependencies
+      - name: Check build
         run: |
           python -m pip install build twine
           python -m build
           twine check --strict dist/*
+
       - name: Publish package distributions to PyPI
         uses: pypa/gh-action-pypi-publish@release/v1
         with:

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -34,11 +34,13 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install -U setuptools
-          pip install tox tox-gh-actions codecov
+          python -m pip install pip twine setuptools tox tox-gh-actions codecov
       - name: Test with tox
         working-directory: ./python
         run: |
           tox
           codecov
+      - name: Check build
+        run: |
+          python -m build
+          twine check --strict dist/*

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -14,7 +14,6 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    timeout-minutes: 20
     strategy:
       matrix:
         python-version:
@@ -26,6 +25,9 @@ jobs:
           - "pypy3.8"
           - "pypy3.9"
           - "pypy3.10"
+    defaults:
+      run:
+        working-directory: python
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
@@ -36,7 +38,6 @@ jobs:
         run: |
           python -m pip install pip setuptools tox tox-gh-actions codecov
       - name: Test with tox
-        working-directory: ./python
         run: |
           tox
           codecov

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -41,7 +41,7 @@ jobs:
         run: |
           tox
           codecov
-      - name: Check build
+      - name: Build package
         run: |
           python -m pip install build twine
           python -m build

--- a/.github/workflows/test-python.yml
+++ b/.github/workflows/test-python.yml
@@ -34,7 +34,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
         run: |
-          python -m pip install pip twine setuptools tox tox-gh-actions codecov
+          python -m pip install pip setuptools tox tox-gh-actions codecov
       - name: Test with tox
         working-directory: ./python
         run: |
@@ -42,5 +42,6 @@ jobs:
           codecov
       - name: Check build
         run: |
+          python -m pip install build twine
           python -m build
           twine check --strict dist/*


### PR DESCRIPTION
### 🤔 What's changed?

Replaces `cucumber/action-publish-pypi` with
`pypa/gh-action-pypi-publish@release/v1`. The motivation for using actions in the cucumber org is to ensure that we do not hand release tokens to untrusted code. As the party publishing our python packages, the Python Package Authority can be trusted. Additionally, their action uses trusted publishers which authorizes GitHub with OIDC so no long-lived tokens are used.

### 🏷️ What kind of change is this?
- :bank: Refactoring/debt/DX (improvement to code design, tooling, etc. without changing behaviour)

