### PR TITLE
Replace all wildcard instances in variable names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- [Java] Replace all wildcard instances in variable names ([#342](https://github.com/cucumber/ci-environment/pull/342))
+- [JavaScript] Replace all wildcard instances in variable names ([#342(https://github.com/cucumber/ci-environment/pull/342))
 
 ## [13.0.0] - 2026-01-26
 ### Changed

--- a/go/detect_environment.go
+++ b/go/detect_environment.go
@@ -141,6 +141,8 @@ func (v *variableExpression) Evaluate() (string, error) {
 func getEnv(name string) string {
 	if strings.Contains(name, "*") {
 		re := regexp.MustCompile(strings.Replace(name, "*", ".*", -1))
+        // GoCD env var with dynamic "material" name
+        // https://github.com/ashwanthkumar/gocd-build-github-pull-requests#github
 		for _, element := range os.Environ() {
 			variable := strings.Split(element, "=")
 			if re.MatchString(variable[0]) {

--- a/java/src/main/java/io/cucumber/cienvironment/VariableExpression.java
+++ b/java/src/main/java/io/cucumber/cienvironment/VariableExpression.java
@@ -47,7 +47,7 @@ final class VariableExpression {
 
     private static @Nullable String getValue(Map<String, String> env, String variable) {
         if (variable.contains("*")) {
-            Pattern pattern = Pattern.compile(variable.replace("*", ".*"));
+            Pattern pattern = Pattern.compile(variable.replaceAll("\\*", ".*"));
             // GoCD env var with dynamic "material" name
             // https://github.com/ashwanthkumar/gocd-build-github-pull-requests#github
             for (Map.Entry<String, String> nameAndValue : env.entrySet()) {

--- a/javascript/src/evaluateVariableExpression.ts
+++ b/javascript/src/evaluateVariableExpression.ts
@@ -19,7 +19,7 @@ export default function evaluateVariableExpression(
       if (!pattern) {
         return value
       }
-      const regExp = new RegExp(pattern.replaceAll('\\/', '/'))
+      const regExp = new RegExp(pattern.replace(/\\\//g, '/'))
       const match = regExp.exec(value)
       if (!match) {
         throw new Error(`No match for: ${variable}`)
@@ -39,7 +39,9 @@ export default function evaluateVariableExpression(
 
 function getValue(env: Env, variable: string) {
   if (variable.includes('*')) {
-    const regexp = new RegExp(variable.replace('*', '.*'))
+    const regexp = new RegExp(variable.replace(/\*/g, '.*'))
+    // GoCD env var with dynamic "material" name
+    // https://github.com/ashwanthkumar/gocd-build-github-pull-requests#github
     for (const [name, value] of Object.entries(env)) {
       if (regexp.exec(name)) {
         return value

--- a/python/src/ci_environment/variable_expression.py
+++ b/python/src/ci_environment/variable_expression.py
@@ -33,6 +33,8 @@ def evaluate(expression, env):
 def get_value(env: dict, variable: str):
     if "*" in variable:
         pattern = compile_re(variable.replace("*", ".*"))
+        # GoCD env var with dynamic "material" name
+        # https://github.com/ashwanthkumar/gocd-build-github-pull-requests#github
         for name, value in env.items():
             if pattern.match(name):
                 return value

--- a/ruby/lib/cucumber/ci_environment/variable_expression.rb
+++ b/ruby/lib/cucumber/ci_environment/variable_expression.rb
@@ -35,8 +35,11 @@ module Cucumber
 
       def get_value(variable, env)
         if variable.index('*')
+          regexp = Regexp.new(variable.gsub('*', '.*'))
+          # GoCD env var with dynamic "material" name
+          # https://github.com/ashwanthkumar/gocd-build-github-pull-requests#github
           env.each do |name, value|
-            return value if Regexp.new(variable.gsub('*', '.*')).match?(name)
+            return value if regexp.match?(name)
           end
         end
         env[variable]


### PR DESCRIPTION
### ⚡️ What's your motivation? 

For GoCD env var can have a dynamic "material" name. E.g. `GO_SCM_*_PR_URL` or `GO_SCM_*_PR_BRANCH`. We replace this wildcard with a `.*` and then look for a matching environment variable using the resulting regex.

For Java and JavaScript we only replace the first occurrence of `*`. CodeQL thinks this is probably a mistake. Though in practice there is only ever one wildcard.

The other implementations also do replace all occurrences so for consistency Java and JavaScript should do the same.


### 🏷️ What kind of change is this?

- :bug: Bug fix (non-breaking change which fixes a defect)


### 📋 Checklist:


- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://github.com/cucumber/.github/tree/main?tab=coc-ov-file)
- [x] I've changed the behaviour of the code
  - [x] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [x] Users should know about my change
  - [x] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../blob/main/CHANGELOG.md), linking to this pull request.
